### PR TITLE
Follow pub.dev from popularity percentile to download counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 2.0.0
+
+- **Breaking**: `PubInfo.popularity` is replaced by `PubInfo.downloadCount30Days`.
+  pub.dev retired the popularity percentile in favour of a 30-day download
+  count. Entries written before the switch have no download count until the
+  cron task visits them again.
+- Null fields are no longer written to the data file.
+- Moved off the `xvrh/pub_api_client` fork to the published `pub_api_client`
+  2.6.0 → 3.2.0. The fork's `PackageScore` required a `lastUpdated` field that
+  pub.dev no longer returns, so every score lookup was throwing.
+- The cron task lists packages with `/api/package-names` again rather than the
+  20k-capped name-completion endpoint, and refuses to run if pub.dev reports
+  fewer packages than the snapshot already holds.
+- The cron task survives a package that fails to load, and fails the job
+  outright if the whole slice fails.
+
 ## 1.0.0
 
 - Initial version.

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -14,7 +14,7 @@ class PubScores {
 
   Map<String, dynamic> toJson() => _$PubScoresToJson(this);
 
-  PubScore? operator[](String name) => packages[name];
+  PubScore? operator [](String name) => packages[name];
 }
 
 @JsonSerializable(includeIfNull: false)
@@ -22,10 +22,7 @@ class PubScore {
   final PubInfo pub;
   final GitHubInfo? github;
 
-  PubScore({
-    required this.pub,
-    required this.github,
-  });
+  PubScore({required this.pub, required this.github});
 
   factory PubScore.fromJson(Map<String, dynamic> json) =>
       _$PubScoreFromJson(json);
@@ -33,17 +30,24 @@ class PubScore {
   Map<String, dynamic> toJson() => _$PubScoreToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(includeIfNull: false)
 class PubInfo {
   final int likeCount;
   final int? grantedPoints;
-  final int? popularity;
+
+  /// Number of downloads over the last 30 days, as reported by pub.dev.
+  ///
+  /// Replaces the former `popularity` percentile, which pub.dev stopped
+  /// serving. Null for entries written before the switch, until the cron task
+  /// visits the package again.
+  final int? downloadCount30Days;
+
   final DateTime lastUpdated;
 
   PubInfo({
     required this.likeCount,
     required this.grantedPoints,
-     required this.popularity,
+    required this.downloadCount30Days,
     required this.lastUpdated,
   });
 
@@ -59,11 +63,7 @@ class GitHubInfo {
   final int starCount;
   final int forkCount;
 
-  GitHubInfo(
-    this.slug, {
-    required this.starCount,
-    required this.forkCount,
-  });
+  GitHubInfo(this.slug, {required this.starCount, required this.forkCount});
 
   factory GitHubInfo.fromJson(Map<String, dynamic> json) =>
       _$GitHubInfoFromJson(json);

--- a/lib/src/model.g.dart
+++ b/lib/src/model.g.dart
@@ -7,60 +7,50 @@ part of 'model.dart';
 // **************************************************************************
 
 PubScores _$PubScoresFromJson(Map<String, dynamic> json) => PubScores(
-      (json['packages'] as Map<String, dynamic>).map(
-        (k, e) => MapEntry(k, PubScore.fromJson(e as Map<String, dynamic>)),
-      ),
-      lastUpdate: json['lastUpdate'] == null
-          ? null
-          : Update.fromJson(json['lastUpdate'] as Map<String, dynamic>),
-    );
+  (json['packages'] as Map<String, dynamic>).map(
+    (k, e) => MapEntry(k, PubScore.fromJson(e as Map<String, dynamic>)),
+  ),
+  lastUpdate: json['lastUpdate'] == null
+      ? null
+      : Update.fromJson(json['lastUpdate'] as Map<String, dynamic>),
+);
 
 Map<String, dynamic> _$PubScoresToJson(PubScores instance) => <String, dynamic>{
-      'packages': instance.packages,
-      'lastUpdate': instance.lastUpdate,
-    };
+  'packages': instance.packages,
+  'lastUpdate': instance.lastUpdate,
+};
 
 PubScore _$PubScoreFromJson(Map<String, dynamic> json) => PubScore(
-      pub: PubInfo.fromJson(json['pub'] as Map<String, dynamic>),
-      github: json['github'] == null
-          ? null
-          : GitHubInfo.fromJson(json['github'] as Map<String, dynamic>),
-    );
+  pub: PubInfo.fromJson(json['pub'] as Map<String, dynamic>),
+  github: json['github'] == null
+      ? null
+      : GitHubInfo.fromJson(json['github'] as Map<String, dynamic>),
+);
 
-Map<String, dynamic> _$PubScoreToJson(PubScore instance) {
-  final val = <String, dynamic>{
-    'pub': instance.pub,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('github', instance.github);
-  return val;
-}
+Map<String, dynamic> _$PubScoreToJson(PubScore instance) => <String, dynamic>{
+  'pub': instance.pub,
+  'github': ?instance.github,
+};
 
 PubInfo _$PubInfoFromJson(Map<String, dynamic> json) => PubInfo(
-      likeCount: json['likeCount'] as int,
-      grantedPoints: json['grantedPoints'] as int?,
-      popularity: json['popularity'] as int?,
-      lastUpdated: DateTime.parse(json['lastUpdated'] as String),
-    );
+  likeCount: (json['likeCount'] as num).toInt(),
+  grantedPoints: (json['grantedPoints'] as num?)?.toInt(),
+  downloadCount30Days: (json['downloadCount30Days'] as num?)?.toInt(),
+  lastUpdated: DateTime.parse(json['lastUpdated'] as String),
+);
 
 Map<String, dynamic> _$PubInfoToJson(PubInfo instance) => <String, dynamic>{
-      'likeCount': instance.likeCount,
-      'grantedPoints': instance.grantedPoints,
-      'popularity': instance.popularity,
-      'lastUpdated': instance.lastUpdated.toIso8601String(),
-    };
+  'likeCount': instance.likeCount,
+  'grantedPoints': ?instance.grantedPoints,
+  'downloadCount30Days': ?instance.downloadCount30Days,
+  'lastUpdated': instance.lastUpdated.toIso8601String(),
+};
 
 GitHubInfo _$GitHubInfoFromJson(Map<String, dynamic> json) => GitHubInfo(
-      json['slug'] as String,
-      starCount: json['starCount'] as int,
-      forkCount: json['forkCount'] as int,
-    );
+  json['slug'] as String,
+  starCount: (json['starCount'] as num).toInt(),
+  forkCount: (json['forkCount'] as num).toInt(),
+);
 
 Map<String, dynamic> _$GitHubInfoToJson(GitHubInfo instance) =>
     <String, dynamic>{
@@ -70,11 +60,11 @@ Map<String, dynamic> _$GitHubInfoToJson(GitHubInfo instance) =>
     };
 
 Update _$UpdateFromJson(Map<String, dynamic> json) => Update(
-      endIndex: json['endIndex'] as int,
-      date: DateTime.parse(json['date'] as String),
-    );
+  endIndex: (json['endIndex'] as num).toInt(),
+  date: DateTime.parse(json['date'] as String),
+);
 
 Map<String, dynamic> _$UpdateToJson(Update instance) => <String, dynamic>{
-      'endIndex': instance.endIndex,
-      'date': instance.date.toIso8601String(),
-    };
+  'endIndex': instance.endIndex,
+  'date': instance.date.toIso8601String(),
+};

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -47,7 +47,8 @@ PubInfo _readPubInfo(JsonReader reader) {
 
   int? likeCount;
   int? grantedPoints;
-  int? popularity;
+  int? downloadCount30Days;
+  DateTime? lastUpdated;
 
   while (reader.hasNextKey()) {
     switch (reader.nextKey()!) {
@@ -59,10 +60,13 @@ PubInfo _readPubInfo(JsonReader reader) {
           grantedPoints = reader.expectInt();
         }
         break;
-      case "popularity":
+      case "downloadCount30Days":
         if (!reader.tryNull()) {
-          popularity = reader.expectInt();
+          downloadCount30Days = reader.expectInt();
         }
+        break;
+      case "lastUpdated":
+        lastUpdated = DateTime.parse(reader.expectString());
         break;
       default:
         reader.skipAnyValue();
@@ -70,10 +74,11 @@ PubInfo _readPubInfo(JsonReader reader) {
   }
 
   return PubInfo(
-      likeCount: likeCount!,
-      grantedPoints: grantedPoints,
-      popularity: popularity,
-      lastUpdated: DateTime(1, 1, 2022));
+    likeCount: likeCount!,
+    grantedPoints: grantedPoints,
+    downloadCount30Days: downloadCount30Days,
+    lastUpdated: lastUpdated!,
+  );
 }
 
 GitHubInfo _readGithubInfo(JsonReader reader) {
@@ -99,9 +104,5 @@ GitHubInfo _readGithubInfo(JsonReader reader) {
     }
   }
 
-  return GitHubInfo(
-    slug!,
-    starCount: starCount!,
-    forkCount: forkCount!,
-  );
+  return GitHubInfo(slug!, starCount: starCount!, forkCount: forkCount!);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,90 +5,74 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: eb376e9acf6938204f90eb3b1f00b578640d3188b4c8a8ec054f9f479af8d051
+      sha256: "9a3386eea899815698dd55995277cf7cb8572ee52b399a6edfb7ae2b50e5fc19"
       url: "https://pub.dev"
     source: hosted
-    version: "64.0.0"
+    version: "105.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "69f54f967773f6c26c7dcb13e93d7ccee8b17a641689da39e878d5cf13b06893"
+      sha256: "62993bed6eadbe9596c5c20d5c167e7bc563c5fe266657a04ddeb93bdb84f4c9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "14.1.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   build:
     dependency: transitive
     description:
       name: build
-      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      sha256: b94f5da9ed3d081fd4ecc426c260998b5f4f4eb2f6d89b7e5472edef0b2b2a1b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "4.0.10"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
+      sha256: "8c0535c3b2f625619f4dd1036ef1127f2e77bfedf89ed2eb2676ef076e0b6712"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: a7417cc44d9edb3f2c8760000270c99dba8c72ff66d0146772b8326565780745
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.1"
+    version: "4.1.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "10c6bcdbf9d049a0b666702cf1cee4ddfdc38f02a19d35ae392863b47519848b"
+      sha256: "90363d438bd9f84a4d5bbb83352251f57d2d9d771bc95a44e6a33fe25fa52774"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: "6d6ee4276b1c5f34f21fdf39425202712d2be82019983d52f351c94aafbc2c41"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.2.10"
+    version: "2.16.0"
   built_collection:
     dependency: transitive
     description:
@@ -101,218 +85,218 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: ff627b645b28fb8bdb69e645f910c2458fd6b65f6585c3a53e0626024897dedf
+      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
       url: "https://pub.dev"
     source: hosted
-    version: "8.6.2"
+    version: "8.12.6"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
-  code_builder:
+    version: "2.0.4"
+  cli_config:
     dependency: transitive
     description:
-      name: code_builder
-      sha256: "315a598c7fbe77f22de1c9da7cfd6fd21816312f16ffa124453b4fc679e540f1"
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.0"
+    version: "0.2.0"
   collection:
     dependency: "direct dev"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.3"
+    version: "1.15.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.7"
+  dart_mappable:
+    dependency: transitive
+    description:
+      name: dart_mappable
+      sha256: "960746478faaa68ed6b9d3c6fd03c87c7b8614e6c33e75fe1b0c6d7a60adcf29"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.8.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
+      sha256: "3f88fc9c96c568d631356507355a2d1e983ee000c9ac008bdcb39b5bf53ce777"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "3.1.12"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   github:
     dependency: "direct dev"
     description:
       name: github
-      sha256: "9966bc13bf612342e916b0a343e95e5f046c88f602a14476440e9b75d2295411"
+      sha256: "707db4b6f1f560cf23750ff4a217988612baed3afb7bd45ec75dc001253c5564"
       url: "https://pub.dev"
     source: hosted
-    version: "9.17.0"
+    version: "9.26.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
+    version: "1.0.5"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.12.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: aa1f5a8912615733e0fdc7a02af03308933c93235bdc8d50d0b0c8a8ccb0b969
+      sha256: e45aefa0324f08c683caafbb94b72837aa6193c61822799c916e45f4a263113d
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.1"
+    version: "6.14.1"
   jsontool:
     dependency: "direct main"
     description:
       name: jsontool
-      sha256: d08f9507f8a8365acf47f6c77dbb23eab1beffc3df2c347e52df6a5a832da5e1
+      sha256: e49bf419e82d90f009426cd7fdec8d54ba8382975b3454ed16a3af3ee1d1b697
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "2.1.0"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "6.1.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.20"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   node_preamble:
     dependency: transitive
     description:
@@ -325,59 +309,58 @@ packages:
     dependency: transitive
     description:
       name: oauth2
-      sha256: c4013ef62be37744efdc0861878fd9e9285f34db1f9e331cc34100d7674feb42
+      sha256: "890a032ba1b44fa8dcfeba500e613df0ecbe16aeace13bb0fe1d25eb42cda5b8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.5"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      sha256: ffcf4cf3d6c0b74ac43708d9f56625506e8a68aa935abe9d267a7330f320eb5d
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.1"
   pool:
     dependency: "direct dev"
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   pub_api_client:
     dependency: "direct dev"
     description:
-      path: "."
-      ref: "099dbae"
-      resolved-ref: "099dbaec4a9ec254cd8fb1a375abc504471413ce"
-      url: "https://github.com/xvrh/pub_api_client.git"
-    source: git
-    version: "2.6.0"
+      name: pub_api_client
+      sha256: bb0338393897235fdf689551e2b49b13e24b432b2da559b00229e784d9a5e680
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.5.0"
   retry:
     dependency: "direct dev"
     description:
@@ -390,10 +373,10 @@ packages:
     dependency: transitive
     description:
       name: shelf
-      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -406,162 +389,178 @@ packages:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "3.0.0"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
-      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
+      sha256: a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "4.2.4"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6adebc0006c37dd63fe05bca0a929b99f06402fc95aa35bf36d67f5c06de01fd"
+      sha256: "5e6f216fdf6376c9f3852381ae037499797a3385377d388b011dac98d303c67c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.4"
+    version: "1.3.13"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.12"
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "9b0dd8e36af4a5b1569029949d50a52cb2a2a2fdaa20cebb96e6603b9ae241f9"
+      sha256: "0d5ba5602ec3baa28c8ce365e1efc5575969c765f45c554a3e167dc7945b9c30"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.6"
+    version: "1.31.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "475610b2aa23c19687cce2961e44b0cc57cafe220f67c2b80201231b2a07fbe7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.13"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "4bef837e56375537055fdbbbf6dd458b1859881f4c7e6da936158f77d61ab265"
+      sha256: a39c204a4fc7a7ccb04a2b985e359fda3cc37e45e0b8ac61c3fb1a05aa832132
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.6"
-  timing:
+    version: "0.6.19"
+  type_plus:
     dependency: transitive
     description:
-      name: timing
-      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      name: type_plus
+      sha256: d5d1019471f0d38b91603adb9b5fd4ce7ab903c879d2fbf1a3f80a630a03fcc9
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "2.1.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "11.10.0"
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -574,9 +573,9 @@ packages:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,12 @@
 name: pub_scores
-description: A sample command-line application.
-version: 1.0.0
-# homepage: https://www.example.com
+description: A periodically refreshed snapshot of pub.dev and GitHub package stats.
+version: 2.0.0
 
 environment:
-  sdk: '^3.1.0'
+  sdk: '^3.8.0'
 
 dependencies:
-  json_annotation:
+  json_annotation: ^4.12.0
   jsontool:
 
 dev_dependencies:
@@ -17,9 +16,6 @@ dev_dependencies:
   github:
   lints:
   pool:
-  pub_api_client:
-    git:
-      url: https://github.com/xvrh/pub_api_client.git
-      ref: '099dbae'
+  pub_api_client: ^3.2.0
   retry:
   test:

--- a/test/pub_scores_test.dart
+++ b/test/pub_scores_test.dart
@@ -1,17 +1,98 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:jsontool/jsontool.dart';
 import 'package:pub_scores/pub_scores.dart';
+import 'package:pub_scores/src/parser.dart';
 import 'package:test/test.dart';
+
+const _dataPath = 'lib/data/all_packages.json';
 
 void main() {
   test('Test read file', () async {
-    var dataPath = 'lib/data/all_packages.json';
-
-    var content = File(dataPath).readAsStringSync();
+    var content = File(_dataPath).readAsStringSync();
     var json = jsonDecode(content) as Map<String, dynamic>;
     var packages = PubScores.fromJson(json);
 
     expect(packages.packages, isNotEmpty);
+  });
+
+  test('Streaming parser reads the same packages', () async {
+    var content = File(_dataPath).readAsBytesSync();
+    var packages = readPubScores(JsonReader.fromUtf8(content));
+
+    expect(packages.packages, isNotEmpty);
+
+    var http = packages['http']!;
+    expect(http.pub.likeCount, greaterThan(0));
+    expect(http.github!.slug, 'dart-lang/http');
+  });
+
+  test('downloadCount30Days round-trips', () {
+    var scores = PubScores({
+      'http': PubScore(
+        pub: PubInfo(
+          likeCount: 10,
+          grantedPoints: 160,
+          downloadCount30Days: 10146592,
+          lastUpdated: DateTime.utc(2026, 1, 1),
+        ),
+        github: null,
+      ),
+    });
+
+    var json = jsonDecode(jsonEncode(scores)) as Map<String, dynamic>;
+    expect(json['packages']['http']['pub']['downloadCount30Days'], 10146592);
+
+    var parsed = PubScores.fromJson(json);
+    expect(parsed['http']!.pub.downloadCount30Days, 10146592);
+  });
+
+  test('Entries written before the download-count switch still parse', () {
+    var json = {
+      'packages': {
+        'legacy': {
+          'pub': {
+            'likeCount': 3,
+            'grantedPoints': 120,
+            'popularity': 97,
+            'lastUpdated': '2024-07-16T20:09:47.863320Z',
+          },
+        },
+      },
+    };
+
+    var pub = PubScores.fromJson(json)['legacy']!.pub;
+    expect(pub.likeCount, 3);
+    expect(pub.downloadCount30Days, isNull);
+
+    var streamed = readPubScores(
+      JsonReader.fromUtf8(utf8.encode(jsonEncode(json))),
+    );
+    expect(streamed['legacy']!.pub.downloadCount30Days, isNull);
+    expect(
+      streamed['legacy']!.pub.lastUpdated,
+      DateTime.utc(2024, 7, 16, 20, 9, 47, 863, 320),
+    );
+  });
+
+  test('Null fields are omitted rather than written out', () {
+    var scores = PubScores({
+      'unscored': PubScore(
+        pub: PubInfo(
+          likeCount: 0,
+          grantedPoints: null,
+          downloadCount30Days: null,
+          lastUpdated: DateTime.utc(2026, 1, 1),
+        ),
+        github: null,
+      ),
+    });
+
+    var pub =
+        (jsonDecode(jsonEncode(scores))
+                as Map<String, dynamic>)['packages']['unscored']['pub']
+            as Map;
+    expect(pub.keys, ['likeCount', 'lastUpdated']);
   });
 }

--- a/tool/cron_task.dart
+++ b/tool/cron_task.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 import 'package:collection/collection.dart';
-import 'package:json_annotation/json_annotation.dart';
 import 'package:pub_scores/src/model.dart';
 import 'package:pub_api_client/pub_api_client.dart';
 import 'package:github/github.dart';
@@ -16,7 +15,20 @@ void main() async {
   var currentPackages = await _loadPackages();
 
   var pubClient = PubClient();
-  var packages = await pubClient.packageNameCompletion();
+  // Not `packageNameCompletion()`: that one hits
+  // `/api/package-name-completion-data`, which pub.dev caps at 20k names. We
+  // need every published package, so `/api/package-names`.
+  var packages = await pubClient.packageNames();
+
+  // The rotation walks this list and everything missing from it gets pruned, so
+  // a truncated answer would quietly delete most of the file.
+  if (packages.length < currentPackages.packages.length) {
+    print(
+      'pub.dev listed only ${packages.length} packages, fewer than the '
+      '${currentPackages.packages.length} already on file. Refusing to run.',
+    );
+    exit(1);
+  }
 
   var startIndex = currentPackages.lastUpdate?.endIndex;
   if (startIndex == null || startIndex >= packages.length) {
@@ -30,19 +42,26 @@ void main() async {
     slicedPackages = [...slicedPackages, ...packages.sublist(0, newEndIndex)];
   }
 
+  var knownPackages = packages.toSet();
   var packageMap = {...currentPackages.packages};
-  packageMap.removeWhere((key, value) => !packages.contains(key));
+  packageMap.removeWhere((key, value) => !knownPackages.contains(key));
 
   var pool = Pool(15);
+  var failures = 0;
 
   for (var packageName in slicedPackages) {
     pool.withResource(() async {
       try {
-        var score = await _loadPackage(pubClient, packageName,
-            previousPackage: currentPackages[packageName]);
+        var score = await _loadPackage(
+          pubClient,
+          packageName,
+          previousPackage: currentPackages[packageName],
+        );
         packageMap[packageName] = score;
-      } on CheckedFromJsonException catch (e) {
-        // Some packages can have malformed pubspec
+      } catch (e) {
+        // A package can be malformed, retracted or simply gone. Nothing here is
+        // awaited, so letting it escape would take the whole run down.
+        ++failures;
         print('Failed to load package: $packageName $e');
       }
     });
@@ -50,13 +69,27 @@ void main() async {
 
   await pool.close();
 
+  print(
+    'Updated ${slicedPackages.length - failures}/${slicedPackages.length} '
+    'packages [$startIndex..$newEndIndex]',
+  );
+
+  // A whole slice failing means the pub.dev API moved under us, not that 500
+  // packages went bad at once. Fail loudly rather than advance endIndex and
+  // silently skip them.
+  if (failures == slicedPackages.length) {
+    print('Every package in the slice failed, leaving the data file alone.');
+    exit(1);
+  }
+
   var newPackages = PubScores({
     for (var entry in packageMap.entries.sortedBy((e) => e.key))
-      entry.key: entry.value
+      entry.key: entry.value,
   }, lastUpdate: Update(date: DateTime.now().toUtc(), endIndex: newEndIndex));
 
-  await _packagesFile
-      .writeAsString(JsonEncoder.withIndent('  ').convert(newPackages));
+  await _packagesFile.writeAsString(
+    JsonEncoder.withIndent('  ').convert(newPackages),
+  );
 
   pubClient.close();
   exit(0);
@@ -64,8 +97,11 @@ void main() async {
 
 final retryOptions = RetryOptions(maxAttempts: 3);
 
-Future<PubScore> _loadPackage(PubClient pubClient, String packageName,
-    {required PubScore? previousPackage}) async {
+Future<PubScore> _loadPackage(
+  PubClient pubClient,
+  String packageName, {
+  required PubScore? previousPackage,
+}) async {
   var packageInfo = await retryOptions.retry(
     () => pubClient.packageInfo(packageName),
   );
@@ -73,7 +109,8 @@ Future<PubScore> _loadPackage(PubClient pubClient, String packageName,
     () => pubClient.packageScore(packageName),
   );
 
-  var repositoryUri = packageInfo.latest.pubspec.repository ??
+  var repositoryUri =
+      packageInfo.latest.pubspec.repository ??
       Uri.tryParse(packageInfo.latest.pubspec.homepage ?? '');
   GitHubInfo? github;
   if (repositoryUri != null && repositoryUri.host == 'github.com') {
@@ -82,8 +119,10 @@ Future<PubScore> _loadPackage(PubClient pubClient, String packageName,
       var repoName = segments.take(2).join('/');
       var extensionToRemove = '.git';
       if (repoName.endsWith(extensionToRemove)) {
-        repoName =
-            repoName.substring(0, repoName.length - extensionToRemove.length);
+        repoName = repoName.substring(
+          0,
+          repoName.length - extensionToRemove.length,
+        );
       }
 
       var slug = RepositorySlug.full(repoName);
@@ -91,9 +130,11 @@ Future<PubScore> _loadPackage(PubClient pubClient, String packageName,
       var githubClient = GitHub(auth: findAuthenticationFromEnvironment());
       try {
         var repository = await githubClient.repositories.getRepository(slug);
-        github = GitHubInfo(repoName,
-            starCount: repository.stargazersCount,
-            forkCount: repository.forksCount);
+        github = GitHubInfo(
+          repoName,
+          starCount: repository.stargazersCount,
+          forkCount: repository.forksCount,
+        );
       } catch (e) {
         print('Failed to load repository info [$repositoryUri]: $e');
         var previousGithub = previousPackage?.github;
@@ -106,20 +147,19 @@ Future<PubScore> _loadPackage(PubClient pubClient, String packageName,
     }
   }
 
-  int? popularity;
-  if (packageScore.popularityScore != null) {
-    popularity = (packageScore.popularityScore! * 100).round();
-  } else {
-    popularity = previousPackage?.pub.popularity;
-  }
+  var downloadCount30Days =
+      packageScore.downloadCount30Days ??
+      previousPackage?.pub.downloadCount30Days;
 
   return PubScore(
-      pub: PubInfo(
-          likeCount: packageScore.likeCount,
-          grantedPoints: packageScore.grantedPoints,
-          lastUpdated: packageInfo.latest.published,
-          popularity: popularity),
-      github: github);
+    pub: PubInfo(
+      likeCount: packageScore.likeCount,
+      grantedPoints: packageScore.grantedPoints,
+      lastUpdated: packageInfo.latest.published,
+      downloadCount30Days: downloadCount30Days,
+    ),
+    github: github,
+  );
 }
 
 Future<PubScores> _loadPackages() async {


### PR DESCRIPTION
pub.dev dropped `popularityScore` and `lastUpdated` from `/api/packages/<name>/score` and replaced them with `downloadCount30Days`.

The cron has not been able to process a single package since. The pinned 2023 fork of `pub_api_client` parses `lastUpdated` unconditionally, so every `packageScore()` call throws `FormatException: Invalid date format`.

## Changes

- `PubInfo.popularity` → `PubInfo.downloadCount30Days`. The percentile is not something pub.dev computes any more, so there was nothing left to refresh it from. Null until the rotation revisits a package. **Breaking**, hence 2.0.0.
- Dropped the `xvrh/pub_api_client` fork for the published `pub_api_client: ^3.2.0`, which carries `downloadCount30Days` plus everything the fork was kept around for (`pubspec_parse`-backed `latest.pubspec`, `close()`). This needed an SDK bump to `^3.8.0` — the current `json_serializable` emits null-aware elements — and a `pub upgrade` of the two-year-old lockfile, which could no longer run `build_runner` under Dart 3.12.
- The streaming parser reads the new field, and parses `lastUpdated` instead of fabricating `DateTime(1, 1, 2022)` (year 1, month 1, *day 2022*).
- `includeIfNull: false` on `PubInfo`, so absent counts don't add 55k null entries to a 15 MB file.
- Tests: the `jsontool` parser had no coverage at all. Added that plus round-trip, legacy-entry and null-omission cases.

## The part that nearly ate the dataset

The fork's `packageNameCompletion()` was a misnomer — it fetched `/api/package-names`. Upstream's method of that name really does hit `/api/package-name-completion-data`, **which pub.dev caps at 20,000**. Since the rotation prunes every package missing from that list, the first run on upstream cut the snapshot from 55,105 entries to 13,941 and reset `endIndex` to 0. It now calls `packageNames()`, and refuses to run if pub.dev reports fewer packages than are already on file.

## Two failure modes that hid this for two years

- An exception inside the unawaited `pool.withResource` took down the whole run; only `CheckedFromJsonException` was caught. Now every package failure is contained and counted.
- A slice that failed in its entirety still wrote the file and advanced `endIndex`, skipping 500 packages in silence and opening a green PR. Now it exits non-zero.

## Verification

`tool/cron_task.dart` run against the live API on a scratch copy: `Updated 500/500 packages [40515..41015]`, download counts populated, GitHub data preserved, 368 pruned packages spot-checked as genuine 404s on pub.dev, 230 new ones added.

`lib/data/all_packages.json` is deliberately untouched here — the next cron run regenerates it. That run will strip `popularity` from all 55k entries, so expect one large diff.

## Downstream

`flutterware` pins this at `ref: master` and reads `pub.popularity` in `app/lib/src/dependencies/list.dart`. Fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)